### PR TITLE
[feat] 대댓글 생성 수정 삭제 추가 , 댓글 작성자 프로필 사진 추가, 대댓글 토글방식으로 표시 추가, 댓글 수정 방식 변경

### DIFF
--- a/server/apps/communitys/urls.py
+++ b/server/apps/communitys/urls.py
@@ -30,7 +30,7 @@ urlpatterns = [
 
     # 대댓글 url
     path('reply_create/', reply_create, name="reply_create"),
-    path('reply_list/', reply_list, name="reply_list"),
+
 
     # 좋아요 url
     path('post_like/', pushPostLike, name="post_like"),

--- a/server/apps/communitys/views.py
+++ b/server/apps/communitys/views.py
@@ -232,10 +232,22 @@ def post_detail(request, pk, bid):
         scraped = True
 
     try:
-        comments = Comment.objects.filter(post = post, parent_comment = None)
+        temp_comments = Comment.objects.filter(post = post, parent_comment = None)
     except Comment.DoesNotExist:
-        comments = []
+        temp_comments = []
 
+    comments=[]
+    for temp_comment in temp_comments:
+        try:
+            child_comments = Comment.objects.filter(post = post, parent_comment = temp_comment)
+        except Comment.DoesNotExist:
+            child_comments = []
+        comment = {'nickname' : temp_comment.commenter.nickname, 'commenter_id' : temp_comment.commenter.id, 'profile' : temp_comment.commenter.image.url,
+                   'id': temp_comment.id, 'content' : temp_comment.content, 'child_comments_num' : temp_comment.child_comments_num,
+                     'child_comments' : child_comments}
+        comments.append(comment)
+    
+    print("comments : ", comments)
 
     # 추후에 작성자가 쓴 다른 글 참조시 사용
     # user = post.user
@@ -335,43 +347,7 @@ def comment_create(request):
 
     newcomment = Comment.objects.create(post = post, commenter = commenter, content = content )      
     
-    return JsonResponse({'commenter' : newcomment.commenter.nickname, 'content' : newcomment.content, 'commentId' : newcomment.id})
-
-
-
-# 함수 이름 : reply_create
-# 전달인자 : request
-# 기능 : --
-@csrf_exempt
-@transaction.atomic
-def reply_create(request):
-    req = json.loads(request.body)
-    post_id = req["post_id"]
-    content = req["content"]
-    parent_comment_id = req["parent_comment_id"]
-    commenter = request.user
-    post = get_object_or_404(Post, id=post_id)
-
-    parent_comment = get_object_or_404(Comment, id=parent_comment_id)
-    print(parent_comment)
-
-    newcomment = Comment.objects.create(post = post, commenter = commenter, content = content, parent_comment = parent_comment )
-    parent_comment.child_comments_num += 1
-    parent_comment.save()
-
-    return JsonResponse({'commenter' : newcomment.commenter.username, 'content' : newcomment.content, 'commentId' : newcomment.id, 'post_id' : post_id})
-
-
-
-
-# 함수 이름 : reply_list
-# 전달인자 : request
-# 기능 : --
-@csrf_exempt
-@transaction.atomic
-def reply_list(request):
-    pass
-
+    return JsonResponse({'commenter' : newcomment.commenter.nickname, 'content' : newcomment.content, 'commentId' : newcomment.id, 'post_id' : post_id, 'profile': commenter.image.url})
 
 
 # 함수 이름 : comment_delete
@@ -384,11 +360,19 @@ def comment_delete(request, pk):
     cid = req["comment_id"]
 
     try:
-        get_object_or_404(Comment, id = cid).delete()
+        target_comment = get_object_or_404(Comment, id = cid)
+        if target_comment.parent_comment == None:
+            reply = 0
+        else:
+            target_comment.parent_comment.child_comments_num -= 1
+            target_comment.parent_comment.save()
+            reply = target_comment.parent_comment.id
+
+        target_comment.delete()
     except 404:
         print("해당 댓글이 더이상 존재하지 않습니다!")
     else:
-        return JsonResponse({'comment_id' : cid})
+        return JsonResponse({'comment_id' : cid, 'isReply' : reply})
 
 
 # 함수 이름 : comment_update
@@ -408,10 +392,40 @@ def comment_update(request, pk):
     else:
         target_comment.content = content
         target_comment.save()
+        if target_comment.parent_comment == None:
+            reply = 0
+        else:
+            reply = 1
 
-    return JsonResponse({'commenter' : target_comment.commenter.username, 'content' : content,'commentId' : cid, 'post_id' : target_comment.post.id})
+    return JsonResponse({ 'content' : content,'commentId' : cid, "ifReply" : reply})
 
 
+
+###########################################################
+#                     대댓글 관련 함수                     #
+###########################################################
+
+# 함수 이름 : reply_create
+# 전달인자 : request
+# 기능 : 대댓글 추가
+@csrf_exempt
+@transaction.atomic
+def reply_create(request):
+    req = json.loads(request.body)
+    post_id = req["post_id"]
+    content = req["content"]
+    parent_comment_id = req["parent_comment_id"]
+    commenter = request.user
+    post = get_object_or_404(Post, id=post_id)
+
+    parent_comment = get_object_or_404(Comment, id=parent_comment_id)
+    print(parent_comment)
+
+    newcomment = Comment.objects.create(post = post, commenter = commenter, content = content, parent_comment = parent_comment )
+    parent_comment.child_comments_num += 1
+    parent_comment.save()
+
+    return JsonResponse({'commenter' : newcomment.commenter.nickname, 'content' : newcomment.content, 'commentId' : newcomment.id, 'post_id' : post_id, 'parent_cid' : parent_comment.id, 'profile': commenter.image.url})
 
 
 

--- a/server/static/locations/javascript/location_review.js
+++ b/server/static/locations/javascript/location_review.js
@@ -3,6 +3,11 @@ const reviewInput = document.querySelector(".input-area");
 
 //리뷰 수정 플래그
 var updateFlag = false;
+// DeadLock 방지
+setInterval(function() {
+  updateFlag = false;
+}, 60 * 1000);
+
 // 리뷰 추가의 별표 추가 버튼
 const addRate = document.querySelector(".addRate");
 // 저장된 값

--- a/server/static/posts/css/post_detail.css
+++ b/server/static/posts/css/post_detail.css
@@ -145,7 +145,8 @@
 }
 .btn-primary:hover, 
 .post-delete-btn:hover, 
-.comment-upload-btn:hover {
+.comment-upload-btn:hover,
+.reply-upload-btn:hover {
   background-color: var(--green--medium--color);
     border: 1px solid var(--green--medium--color);
     transition: 0.1s;
@@ -186,10 +187,14 @@
 .a_comment_content {
   overflow-wrap: break-word;
   width: 100%;
+  font-size: 17px;
 }
-.a_comment_commenter {
-  font-size: 20px;
+.a_reply_content {
+  overflow-wrap: break-word;
+  width: 100%;
+  font-size: 15px;
 }
+
 .post-user {
   display: flex;
   justify-content: space-between;
@@ -241,3 +246,120 @@
     max-width: 500px;
   }
 }
+
+
+
+/* 댓글 프로필 관련*/
+.a_comment_commenter {
+  font-size: 25px;
+  font-weight: bold;
+}
+
+.a_comment_commenter_profile{
+  display:flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 10px;
+
+  margin-bottom: 20px;
+}
+
+.a_comment_commenter_image{
+  width: 30px;
+  height: 30px;
+}
+
+
+.a_reply_commenter{
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.a_reply_commenter_profile{
+  display:flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+
+  margin-bottom: 15px;
+}
+
+.a_reply_commenter_image{
+  width: 20px;
+  height: 20px;
+}
+
+
+
+
+/*****************************/
+/*         대댓글 관련        */
+/*****************************/
+
+/* 대댓글 영역 */
+.replySection{
+  display:none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+
+/* 대댓글 하나  */
+.a_reply{
+  padding: 10px;
+  padding-left : 20px;
+  background-color: var(--green--pale--color);
+  border-radius: 5px;
+  margin: 10px 0px;
+
+  width:100%;
+
+  filter :brightness(0.8)
+}
+
+/* 대댓글 열람 버튼 */
+.show_a_comment_reply{
+  color:#1dc078;
+  font-weight: bold;
+  cursor:pointer;
+}
+
+.show_a_comment_reply:hover{
+  filter:brightness(1.1);
+}
+
+
+/* 대댓글 입력 칸 한 줄 속성*/
+.reply-input-area{
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  background-color: var(--green--pale--color);
+}
+/* 대댓글 입력 칸 속성 */
+.reply-input-box{
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  box-sizing: border-box;
+  background-color: #ffffff;
+
+  margin-top: 10px;
+}
+
+.reply-upload-btn{
+  padding: 10px;
+  border-radius: 5px;
+  border: 1px solid var(--green--medium--color);
+  background-color: var(--green--bright--color);
+  cursor: pointer;
+  width: 100px;
+  font-size: 10px;
+  color: white;
+  line-height: 1;
+}
+
+

--- a/server/static/posts/js/comment.js
+++ b/server/static/posts/js/comment.js
@@ -4,7 +4,7 @@ const requestCommentDelete = new XMLHttpRequest();
 
 // 함수명 : deleteComment
 // 전달인자 : post_id
-// 기능 : 서버에 댓글 삭제 요청 및, 해당 post_id 전달
+// 기능 : 서버에 댓글 삭제 요청 및, 해당 post_id 전달 ---> 대댓글도 이 함수로 실행
 function deleteComment(comment_id) {
   const url = `/communitys/comment_delete/${comment_id}/`;
   requestCommentDelete.open("POST", url, true);
@@ -15,13 +15,34 @@ function deleteComment(comment_id) {
   requestCommentDelete.send(JSON.stringify({ comment_id: comment_id }));
 }
 
-// 댓글 삭제 요청 응답 온 후
+// 댓글 삭제 요청 응답 온 후.... 대댓글도 가능
 requestCommentDelete.onreadystatechange = () => {
   if (requestCommentDelete.readyState === XMLHttpRequest.DONE) {
     if (requestCommentDelete.status < 400) {
-      const { comment_id } = JSON.parse(requestCommentDelete.response);
+      const { comment_id, isReply} = JSON.parse(requestCommentDelete.response);
       const element = document.querySelector(`.Cid-${comment_id}`);
       element.remove();
+      // 원댓글이 아닐 경우
+      if (isReply != 0){
+        // isReply 는 해당 댓글의 부모의 id 값
+        const showReplybtn = document.querySelector(`.showReply-${isReply}`)
+        const [text1, child_num, text2] = showReplybtn.innerHTML.split(" ");
+        if (child_num == 1){
+          showReplybtn.remove()
+        }
+        else{
+          showReplybtn.innerHTML = `-답글 ${Number(child_num) - 1} 개-`
+          showReplybtn.addEventListener("click", (event)=>{
+            const target = event.target;
+            const replyArea = target.parentNode.nextElementSibling;
+            console.log(replyArea)
+            console.log( window.getComputedStyle(replyArea).style.display)
+
+            replyArea.style.display = (window.getComputedStyle(replyArea).style.display === 'flex') ? 'none' : 'flex';
+            console.log("삭제후 표시 토글")
+          })
+        }
+      }
     }
   }
 };
@@ -56,39 +77,44 @@ function writeComment(post_id) {
 requestCommentAdd.onreadystatechange = () => {
   if (requestCommentAdd.readyState === XMLHttpRequest.DONE) {
     if (requestCommentAdd.status < 400) {
-      const { commenter, content, commentId, post_id } = JSON.parse(
+      const { commenter, content, commentId, post_id, profile } = JSON.parse(
         requestCommentAdd.response
       );
       const element = document.querySelector(".commentSection");
       let originHTML = element.innerHTML;
-      element.innerHTML += `<div class="a_comment Cid-${commentId}">
-            <div class="a_comment_commenter">${commenter}</div>
-            <div class="a_comment_content">${content}</div>
-            <button
-              class="a_comment_delete"
-              onclick="deleteComment(${commentId})"
-            >
-              삭제
-            </button>
-            <button
-              class="a_comment_delete"
-              onclick="updateCommentBtn(${commentId})"
-            >
-              수정
-            </button>
-            <button
-              class="a_comment_delete"
-              onclick="likeComment(${commentId})"
-            >
-              좋아요
-            </button>
-            <button
-              class="a_comment_reply"
-              onclick="writeReply(${post_id}, ${commentId})"
-            >
-              답글
-            </button>
-            </div><section class="replySection"></section>`;
+      element.innerHTML += `
+      <div class="a_comment Cid-${commentId}">
+        <div class="a_comment_commenter_profile">
+          <img class="a_comment_commenter_image" src="${profile}"></img>
+          <div class="a_comment_commenter">${commenter}</div>
+        </div>
+        <div class="a_comment_content">${content}</div>
+        <div class="comment-btns">
+          <button
+            class="a_comment_delete"
+            onclick="deleteComment(${commentId})"
+          >
+            삭제
+          </button>
+          <button
+            class="a_comment_delete"
+            onclick="updateCommentBtn(${commentId})"
+          >
+            수정
+          </button>
+          <button
+            class="a_comment_reply"
+            onclick="showReplyInput(${post_id}, ${commentId})"
+          >
+            답글
+          </button>
+        </div>
+        <div>
+          <div class="showReplyBtnArea-${commentId}"></div>
+          <div class="replySection replyTo-${commentId}"></div>
+        </div>
+      </div>`;
+
     }
   }
 };
@@ -99,7 +125,7 @@ const requestCommentUpdate = new XMLHttpRequest();
 
 // 함수명 : updateComment
 // 전달인자 : comment_id
-// 기능 : 서버에 댓글 작성 요청 및 댓글 내용 전달
+// 기능 : 서버에 댓글 수정 요청 및 댓글 내용 전달  ---> 대댓글도 이 함수로 실행
 function updateComment(comment_id) {
   //기존 댓글
   const content = document.querySelector(".comment-update-box");
@@ -123,39 +149,13 @@ function updateComment(comment_id) {
 requestCommentUpdate.onreadystatechange = () => {
   if (requestCommentUpdate.readyState === XMLHttpRequest.DONE) {
     if (requestCommentUpdate.status < 400) {
-      const { commenter, content, commentId, post_id } = JSON.parse(
+      const { content, commentId,ifReply} = JSON.parse(
         requestCommentUpdate.response
       );
       const element = document.querySelector(`.Cid-${commentId}`);
-      element.innerHTML = `<div class="a_comment_commenter">${commenter}</div>
-            <div class="a_comment_content">${content}</div>
-            <div class="comment-btns">
-            <button
-              class="a_comment_delete"
-              onclick="deleteComment(${commentId})"
-            >
-              삭제
-            </button>
-            <button
-              class="a_comment_delete"
-              onclick="updateCommentBtn(${commentId})"
-            >
-              수정
-            </button>
-            <button
-              class="a_comment_delete"
-              onclick="likeComment(${commentId})"
-            >
-              좋아요
-            </button>
-            <button
-              class="a_comment_reply"
-              onclick="writeReply(${post_id}, ${commentId})"
-            >
-              답글
-            </button>
-            </div>
-            <section class="replySection"></section>`;
+      if (ifReply){ const new_content = element.querySelector('.a_reply_content');  new_content.innerHTML = `${content}`;}
+      else{ const new_content = element.querySelector('.a_comment_content'); new_content.innerHTML = `${content}`;}
+      
     }
   }
 };
@@ -166,8 +166,24 @@ requestCommentUpdate.onreadystatechange = () => {
 function updateCommentBtn(comment_id) {
   const element = document.querySelector(`.Cid-${comment_id}`);
   const commentElement = element.querySelector(".a_comment_content");
-  element.innerHTML = `<div class="input-area">
+  commentElement.innerHTML = `<div class="input-area">
         <input type="text" class="comment-update-box" value="${commentElement.innerHTML}"/><button
+          class="comment-upload-btn"
+          onclick="updateComment(${comment_id})"
+        >
+          수정
+        </button>
+      </div>`;
+}
+
+// 함수명 : updateReplyBtn
+// 전달인자 : comment_id
+// 기능 : 대댓글 업데이트 버튼 입력시 input 칸으로 변경
+function updateReplyBtn(comment_id) {
+  const element = document.querySelector(`.Cid-${comment_id}`);
+  const replyElement = element.querySelector(".a_reply_content");
+  replyElement.innerHTML = `<div class="input-area">
+        <input type="text" class="comment-update-box" value="${replyElement.innerHTML}"/><button
           class="comment-upload-btn"
           onclick="updateComment(${comment_id})"
         >

--- a/server/static/posts/js/reply.js
+++ b/server/static/posts/js/reply.js
@@ -1,69 +1,21 @@
 // 대댓글 열람 부분
+const openReplyBtns = document.querySelectorAll(".show_a_comment_reply")
+openReplyBtns.forEach((btn)=>{
+  btn.addEventListener("click", (event)=>{
+    const target = event.target;
+    const replyArea = target.parentNode.nextElementSibling;
+    replyArea.style.display = (replyArea.style.display === 'flex') ? 'none' : 'flex';
+  })
+})
 
-//새 HTTPRequest 생성
-const requestReplyOpen = new XMLHttpRequest();
 
-// 함수명 : writeReply
-// 전달인자 : post_id
-// 기능 : 서버에 댓글 작성 요청 및 댓글 내용 전달
-function openReply(post_id, parent_comment_id) {
-  const url = `/communitys/comment_create/`;
-  requestReplyOpen.open("POST", url, true);
-  requestReplyOpen.setRequestHeader(
-    "Content-Type",
-    "application/x-www-form-urlencoded"
-  );
-  requestReplyOpen.send(
-    JSON.stringify({
-      post_id: post_id,
-      parent_comment_id: parent_comment_id,
-    })
-  );
-}
+// 다른 대댓글 작성 방지 flag
+let reCommentFlag = false;
+// DeadLock 방지
+setInterval(function() {
+  reCommentFlag = false;
+}, 60 * 1000);
 
-// 대댓글 열람 요청 응답 온 후
-requestReplyOpen.onreadystatechange = () => {
-  if (requestReplyOpen.readyState === XMLHttpRequest.DONE) {
-    if (requestReplyOpen.status < 400) {
-      const { commenter, content, commentId, post_id } = JSON.parse(
-        requestReplyOpen.response
-      );
-
-      const element = document.querySelector(".commentSection");
-      let originHTML = element.innerHTML;
-      element.innerHTML += `<div class="a_comment Cid-${commentId}">
-            <div class="a_comment_commenter">${commenter}</div>
-            <div class="a_comment_content">${content}</div>
-            <button
-              class="a_comment_delete"
-              onclick="deleteComment(${commentId})"
-            >
-              삭제
-            </button>
-            <button
-              class="a_comment_delete"
-              onclick="updateCommentBtn(${commentId})"
-            >
-              수정
-            </button>
-            <button
-              class="a_comment_delete"
-              onclick="likeComment(${commentId})"
-            >
-              좋아요
-            </button>
-            <button
-              class="a_comment_reply"
-              onclick="replyComment(${post_id}, ${commentId})"
-            >`;
-    }
-  }
-};
-
-// 대댓글 탭 닫기
-function closeReply(post_id, parent_comment_id) {
-  const content = document.querySelector(".comment-input-box");
-}
 
 // 대댓글 추가 부분
 
@@ -74,9 +26,9 @@ const requestReplyAdd = new XMLHttpRequest();
 // 전달인자 : post_id
 // 기능 : 서버에 댓글 작성 요청 및 댓글 내용 전달
 function writeReply(post_id, parent_comment_id) {
-  const content = document.querySelector(".comment-input-box");
+  const content = document.querySelector(".reply-input-box");
 
-  const url = `/communitys/comment_create/`;
+  const url = `/communitys/reply_create/`;
   requestReplyAdd.open("POST", url, true);
   requestReplyAdd.setRequestHeader(
     "Content-Type",
@@ -90,38 +42,104 @@ function writeReply(post_id, parent_comment_id) {
     })
   );
   content.value = "";
+
+  // 전송 요청 보냈으니 다른 댓글 작성 가능
+  reCommentFlag = false;
 }
 
 // 대댓글 추가 요청 응답 온 후
 requestReplyAdd.onreadystatechange = () => {
   if (requestReplyAdd.readyState === XMLHttpRequest.DONE) {
     if (requestReplyAdd.status < 400) {
-      const { commenter, content, commentId, post_id } = JSON.parse(
+      const { commenter, content, commentId, parent_cid, profile } = JSON.parse(
         requestReplyAdd.response
       );
-      const element = document.querySelector(".commentSection");
-      let originHTML = element.innerHTML;
-      element.innerHTML += `<div class="a_comment Cid-${commentId}">
-            <div class="a_comment_commenter">${commenter}</div>
-            <div class="a_comment_content">${content}</div>
-            <button
-              class="a_comment_delete"
-              onclick="deleteComment(${commentId})"
-            >
-              삭제
-            </button>
-            <button
-              class="a_comment_delete"
-              onclick="updateCommentBtn(${commentId})"
-            >
-              수정
-            </button>
-            <button
-              class="a_comment_delete"
-              onclick="likeComment(${commentId})"
-            >
-              좋아요
-            </button>`;
+
+
+      // 대댓글 해당 댓글 아래에 추가하기
+      const replySection = document.querySelector(`.replyTo-${parent_cid}`);
+      replySection.innerHTML += `
+      <div class="a_reply Cid-${commentId}">
+        <div class="a_reply_commenter_profile">
+          <img class="a_reply_commenter_image" src="${profile}"></img>
+          <div class="a_reply_commenter">${commenter}</div>
+        </div>
+        <div class="a_reply_content">${content}</div>
+        <div class="comment-btns">
+          <button
+            class="a_comment_delete"
+            onclick="deleteComment(${commentId})"
+          >
+            삭제
+          </button>
+          <button
+            class="a_comment_delete"
+            onclick="updateReplyBtn(${commentId})"
+          >
+            수정
+          </button>
+        </div>
+       </div>`;
+
+       // 답글 개수 수정하기
+       const showReplyBtnArea = document.querySelector(`.showReplyBtnArea-${parent_cid}`)
+       // 아무것도 없을 때
+       if (showReplyBtnArea.innerHTML.trim() === ''){
+        showReplyBtnArea.innerHTML = `<button class="show_a_comment_reply showReply-${parent_cid}">-답글 1 개-</button>`
+        showReplyBtnArea.firstElementChild.addEventListener("click", (event)=>{
+          const target = event.target;
+          const replyArea = target.parentNode.nextElementSibling;
+          replyArea.style.display = (replyArea.style.display === 'flex') ? 'none' : 'flex';
+        })
+       }
+       //이미 있을 때
+       else{
+        let button_innerText = showReplyBtnArea.firstElementChild.innerHTML
+        const [text1, child_num, text2] = button_innerText.split(" ");
+        showReplyBtnArea.firstElementChild.innerHTML = `-답글 ${Number(child_num) + 1} 개-`
+        showReplyBtnArea.firstElementChild.addEventListener("click", (event)=>{
+          const target = event.target;
+          const replyArea = target.parentNode.nextElementSibling;
+          replyArea.style.display = (replyArea.style.display === 'flex') ? 'none' : 'flex';
+        })
+       }
+
+      //  대댓글 입력칸 없애기
+      const target_comment = document.querySelector(".reply-input-area")
+      target_comment.remove()
     }
   }
 };
+
+
+//대댓글 입력 취소
+function cancelReply(){
+  reCommentFlag = false;
+  //  대댓글 입력칸 없애기
+  const target_comment = document.querySelector(".reply-input-area")
+  target_comment.remove()
+}
+
+
+// 대댓글 입력창 추가
+function showReplyInput(post_id, comment_id){
+  // 대댓글 현재 작성 여부 체크
+  if (reCommentFlag){
+    alert("다른 수정중인 대댓글을 먼저 작성 완료해주세요!")
+    return;
+  }
+  reCommentFlag = true;
+
+  // 답글 누르면 자동으로 열리기
+  const replyArea = document.querySelector(`.replyTo-${comment_id}`)
+  replyArea.style.display = 'flex';
+  // replyArea.style.display = (replyArea.style.display === 'flex') ? 'none' : 'flex';
+
+  const target_comment = document.querySelector(`.Cid-${comment_id}`)
+  target_comment.innerHTML += `
+  <div class="reply-input-area">
+    <input type="text" class="reply-input-box" />
+    <button class="reply-upload-btn" onclick="writeReply(${post_id}, ${comment_id})">대댓글 등록</button>
+    <button class="reply-upload-btn" onclick="cancelReply()">취소</button>
+  </div>`
+}

--- a/server/templates/communitys/posts/post_detail.html
+++ b/server/templates/communitys/posts/post_detail.html
@@ -1,90 +1,76 @@
-{% extends 'base.html' %} {%load static%} {% block content %}
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>파골원 커뮤 디테일</title>
-    <link rel="stylesheet" href="{%static 'posts/css/post_detail.css'%}" />
-  </head>
-  <body>
-    <div class="before-icons">
-      <a href="{% url 'communitys:board_list' %}" class="before-icon">
-        <span class="bxs--left-arrow"></span>
-        <div>커뮤니티 홈</div>
-      </a>
-      <a href="{% url 'communitys:post_list' bid %}" class="before-icon">
-        <div>게시판 홈</div>
-        <span class="bxs--right-arrow"></span>
-      </a>
-    </div>
-    <div class="post-detail-container">
-      <div class="post-info">
-        <h1 class="post-detail-title">{{post.title}}</h1>
-        <div class="post-write-info">
-          <div>
-            <img src="{{ user.image.url }}" alt="프로필사진" class="mypage-img">
-          <div>
-            <h4>{{post.writer}}</h4>
-            <span>{{post.created_date}}</span>
-            <span class="view">조회 {{post.view_num}}</span>
-          </div>
+{% extends 'base.html' %} {% load static %} {% block content %}
+  <!DOCTYPE html>
+  <html lang="en">
+    <head>
+      <meta charset="UTF-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <title>파골원 커뮤 디테일</title>
+      <link rel="stylesheet" href="{% static 'posts/css/post_detail.css' %}" />
+    </head>
+    <body>
+      <div class="before-icons">
+        <a href="{% url 'communitys:board_list' %}" class="before-icon">
+          <span class="bxs--left-arrow"></span>
+          <div>커뮤니티 홈</div>
+        </a>
+        <a href="{% url 'communitys:post_list' bid %}" class="before-icon">
+          <div>게시판 홈</div>
+          <span class="bxs--right-arrow"></span>
+        </a>
+      </div>
+      <div class="post-detail-container">
+        <div class="post-info">
+          <h1 class="post-detail-title">{{ post.title }}</h1>
+          <div class="post-write-info">
+            <div>
+              <img src="{{ user.image.url }}" alt="프로필사진" class="mypage-img" />
+              <div>
+                <h4>{{ post.writer }}</h4>
+                <span>{{ post.created_date }}</span>
+                <span class="view">조회 {{ post.view_num }}</span>
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-      {% if post.photo.url != '' %}
-      <img src="{{post.photo.url}}" alt="게시글 이미지" />
-      {% endif %}
-      <h2 class="my-3">{{ post.content|safe }}</h2>
-      <div>[공유하기 넣을 곳]</div>
-      <div class="post-user">
-        <div class="post_buttons">
-          {% if user.is_authenticated %} {%if liked%}
-          <button
-            class="postLikeBtn like-{{post.id}} liked"
-            onclick="pushLike({{post.id}})"
-          ></button>
-          {%else%}
-          <button
-            class="postLikeBtn like-{{post.id}}"
-            onclick="pushLike({{post.id}})"
-          ></button>
-          {% endif %} 
-          <div class="likeNum-{{post.id}}"> {{post.like_num}}</div>
-          {%if scraped%}
-          <button
-            class="postScrapBtn scrap-{{post.id}} scraped"
-            onclick="pushScrap({{post.id}})"
-          ></button>
-          {%else%}
-          <button
-            class="postScrapBtn scrap-{{post.id}}"
-            onclick="pushScrap({{post.id}})"
-          ></button>
-          {% endif %} <div class="scrapNum-{{post.id}}"> {{post.scrap_num}}</div>
-          {% else %}
-          <div class="likeNum-{{post.id}}"><span class="material-symbols--thumb-up"></span>{{post.like_num}}</div>
-          <div class="scrapNum-{{post.id}}"><span class="tdesign--star-filled"></span>{{post.scrap_num}}</div>
+        {% if post.photo.url != '' %}
+          <img src="{{ post.photo.url }}" alt="게시글 이미지" />
+        {% endif %}
+        <h2 class="my-3">{{ post.content|safe }}</h2>
+        <div>[공유하기 넣을 곳]</div>
+        <div class="post-user">
+          <div class="post_buttons">
+            {% if user.is_authenticated %}
+              {% if liked %}
+                <button class="postLikeBtn like-{{ post.id }} liked" onclick="pushLike({{ post.id }})"></button>
+              {% else %}
+                <button class="postLikeBtn like-{{ post.id }}" onclick="pushLike({{ post.id }})"></button>
+              {% endif %}
+              <div class="likeNum-{{ post.id }}">{{ post.like_num }}</div>
+              {% if scraped %}
+                <button class="postScrapBtn scrap-{{ post.id }} scraped" onclick="pushScrap({{ post.id }})"></button>
+              {% else %}
+                <button class="postScrapBtn scrap-{{ post.id }}" onclick="pushScrap({{ post.id }})"></button>
+              {% endif %} <div class="scrapNum-{{ post.id }}">{{ post.scrap_num }}</div>
+            {% else %}
+              <div class="likeNum-{{ post.id }}">
+                <span class="material-symbols--thumb-up"></span>{{ post.like_num }}
+              </div>
+              <div class="scrapNum-{{ post.id }}">
+                <span class="tdesign--star-filled"></span>{{ post.scrap_num }}
+              </div>
+            {% endif %}
+          </div>
+          {% if post.writer == now_user %}
+            <div class="post-detail-btns">
+              <form action="{% url 'communitys:post_delete' bid post.pk %}" method="POST">
+                {% csrf_token %}
+                <a href="{% url 'communitys:post_update' bid post.pk %}" class="btn btn-primary">수정하기</a>
+                <button type="submit" class="post-delete-btn">삭제하기</button>
+              </form>
+            </div>
           {% endif %}
         </div>
-        {% if post.writer == now_user %}
-          <div class="post-detail-btns">
-            <form
-              action="{% url 'communitys:post_delete' bid post.pk %}"
-              method="POST"
-            >
-              {%csrf_token%}
-              <a
-                href="{% url 'communitys:post_update' bid post.pk %}"
-                class="btn btn-primary"
-                >수정하기</a
-              >
-              <button type="submit" class="post-delete-btn">삭제하기</button>
-            </form>
-          </div>
-          {% endif %}
-      </div>
-      <!-- {% if post.writer == now_user %}
+        <!--                                  {% if post.writer == now_user %}
       <div class="post-detail-btns">
         <form
           action="{% url 'communitys:post_delete' bid post.pk %}"
@@ -99,77 +85,71 @@
           <button type="submit" class="post-delete-btn">삭제하기</button>
         </form>
       </div>
-      {% endif %} -->
-      <div class="commentSection">
-        {% if comments %} {% for comment in comments%}
-        <div class="a_comment Cid-{{comment.id}}">
-          <div class="a_comment_commenter">{{comment.commenter.nickname}}</div>
-          <div class="a_comment_content">{{comment.content}}</div>
-          <div class="comment-btns">
-            {% if comment.commenter == now_user%}
-            <button
-              class="a_comment_delete"
-              onclick="deleteComment({{comment.id}})"
-            >
-              삭제
-            </button>
-            <button
-              class="a_comment_delete"
-              onclick="updateCommentBtn({{comment.id}})"
-            >
-              수정
-            </button>
-            {% endif %} {% if user.is_authenticated %}
-            <button
-              class="a_comment_delete"
-              onclick="likeComment({{comment.id}})"
-            >
-              좋아요
-            </button>
-            <button
-              class="a_comment_reply"
-              onclick="writeReply({{post.id}}, {{comment.id}})"
-            >
-              답글
-            </button>
-            {% endif %} {% if comment.child_comments_num > 0 %}
-            <div>
-              <button
-                class="a_comment_reply"
-                onclick="openReply({{post.id}}, {{comment.id}})"
-              >
-                답글 {{comment.child_comments_num}} 개
-              </button>
-            </div>
-            {% endif %}
-          </div>
-          <section class="replySection"></section>
+      {% endif %}                                  -->
+        <div class="commentSection">
+          {% if comments %}
+            {% for comment in comments %}
+              <div class="a_comment Cid-{{ comment.id }}">
+                <div class="a_comment_commenter_profile">
+                  <img class="a_comment_commenter_image" src="{{comment.profile}}"></img>
+                  <div class="a_comment_commenter">{{ comment.nickname }}</div>
+                </div>
+                <div class="a_comment_content">{{ comment.content }}</div>
+                <div class="comment-btns">
+                  {% if comment.commenter_id == now_user.id %}
+                    <button class="a_comment_delete" onclick="deleteComment({{ comment.id }})">삭제</button>
+                    <button class="a_comment_delete" onclick="updateCommentBtn({{ comment.id }})">수정</button>
+                  {% endif %} {% if user.is_authenticated %}
+                    <button class="a_comment_reply" onclick="showReplyInput({{ post.id }}, {{ comment.id }})">답글</button>
+                  {% endif %}
+                </div>
+
+                <div>
+
+                    <div class="showReplyBtnArea-{{ comment.id }}">
+                      {% if comment.child_comments_num > 0 %}
+                      <button class="show_a_comment_reply showReply-{{ comment.id }}">-답글 {{ comment.child_comments_num }} 개-</button>
+                      {% endif %}
+                    </div>
+
+                  <div class="replySection replyTo-{{ comment.id }}">
+                    {% for child_comment in comment.child_comments %}
+                      <div class="a_reply Cid-{{ child_comment.id }}">
+                        <div class="a_reply_commenter_profile">
+                          <img class="a_reply_commenter_image" src="{{ child_comment.commenter.image.url}}"></img>
+                          <div class="a_reply_commenter">{{ child_comment.commenter.nickname }}</div>
+                        </div>
+                        <div class="a_reply_content">{{ child_comment.content }}</div>
+                        <div class="comment-btns">
+                          <button class="a_comment_delete" onclick="deleteComment({{ child_comment.id }})">삭제</button>
+                          <button class="a_comment_delete" onclick="updateReplyBtn({{ child_comment.id }})">수정</button>
+                        </div>
+                      </div>
+                    {% endfor %}
+                  </div>
+                </div>
+              </div>
+            {% endfor %}
+          {% endif %}
         </div>
-        {%endfor%} {% endif%}
+        <hr />
+        {% if user.is_authenticated %}
+          <div class="input-area">
+            <input type="text" class="comment-input-box" /><button class="comment-upload-btn" onclick="writeComment({{ post.id }})">댓글 등록</button>
+          </div>
+        {% else %}
+          <div class="input-area">
+            <span>댓글을 작성하려면 로그인을 해주세요!</span>
+          </div>
+        {% endif %}
+        <hr />
       </div>
-      <hr />
-      {% if user.is_authenticated %}
-      <div class="input-area">
-        <input type="text" class="comment-input-box" /><button
-          class="comment-upload-btn"
-          onclick="writeComment({{post.id}})"
-        >
-          댓글 등록
-        </button>
-      </div>
-      {%else%}
-      <div class="input-area">
-        <span> 댓글을 작성하려면 로그인을 해주세요!</span>
-      </div>
-      {% endif%}
-      <hr />
-    </div>
-    <!-- 댓글 -->
-    <script src="{% static 'posts/js/comment.js'%}"></script>
-    <!-- 대댓글  -->
-    <script src="{% static 'posts/js/reply.js'%}"></script>
-    <!-- 좋아요 & 스크랩 -->
-    <script src="{% static 'posts/js/like_scrap.js' %}"></script>
-  </body>
-</html>
+      <!-- 댓글 -->
+      <script src="{% static 'posts/js/comment.js' %}"></script>
+      <!-- 대댓글 -->
+      <script src="{% static 'posts/js/reply.js' %}"></script>
+      <!-- 좋아요 & 스크랩 -->
+      <script src="{% static 'posts/js/like_scrap.js' %}"></script>
+    </body>
+  </html>
 {% endblock %}


### PR DESCRIPTION
대댓글 기능 추가
1. 대댓글 작성
-> 대댓글 추가 가능 (한번에 하나만 작성 가능)
-> 플래그를 사용하였고, deadlock 방지 적용완료
-> 추가시 대댓글 토글창 생성/변경
2. 대댓글 수정
-> 대댓글 수정 가능
3. 대댓글 삭제
-> 삭제시 대댓글 토글창 제거/변경
4. 대댓글 토글
-> -답글 n개- 클릭시 답글 표시 토글 (유튜브 참조)
5. 댓글 작성자 -> 닉네임으로 변경
6. 댓글 작성자 프로필 사진 추가 완료
7. 댓글 수정 방식 변경
-> 콘텐츠 창만 수정하도록 바꾸었음 (추후에 리뷰도 이와 같이 수정하면 좋을듯!)

@@ 댓글 좋아요와 페이지네이션은 아직 넣지 않았음. 내일 회의하면서 결정... 아 오늘이지...@@
